### PR TITLE
Multiverse and cardmarket ID support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Scryfall::Cards.with_arena_id 67330
 # ... by its TCG Player id ...
 Scryfall::Cards.with_tcgplayer_id 164756
 
+# ... by its Multiverse id ...
+Scryfall::Cards.with_multiverse_id 443001
+
+# ... by its Cardmarket id ...
+Scryfall::Cards.with_cardmarket_id 355353
+
 # ... or by its unique ID.
 Scryfall::Cards.with_id "645cfc1b-76f2-4823-9fb0-03cb009f8b32"
 ```

--- a/lib/scryfall/cards.rb
+++ b/lib/scryfall/cards.rb
@@ -31,6 +31,14 @@ module Scryfall
       api.get "/cards/tcgplayer/#{id}", {}, **args
     end
 
+    def self.with_multiverse_id(id, **args)
+      api.get "/cards/multiverse/#{id}", {}, **args
+    end
+
+    def self.with_cardmarket_id(id, **args)
+      api.get "/cards/cardmarket/#{id}", {}, **args
+    end
+
     def self.with_id(id, **args)
       api.get "/cards/#{id}", {}, **args
     end

--- a/scryfall.gemspec
+++ b/scryfall.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name        = 'scryfall'
-  s.version     = '0.2.10'
+  s.version     = '0.3.0'
   s.date        = '2018-09-20'
   s.summary     = 'A gem made to contact Scryfall API'
   s.description = 'A simple way to connect with Scryfall API and get MTG Card info easily'

--- a/spec/scryfall_spec.rb
+++ b/spec/scryfall_spec.rb
@@ -36,6 +36,8 @@ describe Scryfall::Cards do
       @mtgo_id = 67_691
       @arena_id = 67_330
       @tcgplayer_id = 164_756
+      @multiverse_id = 443001
+      @cardmarket_id = 355353
     end
 
     it 'should get a card by ID' do
@@ -45,6 +47,8 @@ describe Scryfall::Cards do
       expect(resp['tcgplayer_id']).to eql(@tcgplayer_id)
       expect(resp['mtgo_id']).to eql(@mtgo_id)
       expect(resp['arena_id']).to eql(@arena_id)
+      expect(resp['multiverse_ids']).to include(@multiverse_id)
+      expect(resp['cardmarket_id']).to eql(@cardmarket_id)
     end
 
     it 'should get a card by its MTGO id' do
@@ -69,6 +73,22 @@ describe Scryfall::Cards do
       expect(resp['id']).to eql(@card_id)
       expect(resp['object']).to eql('card')
       expect(resp['tcgplayer_id']).to eql(@tcgplayer_id)
+    end
+
+    it 'should get a card by its Multiverse id' do
+      resp = Scryfall::Cards.with_multiverse_id @multiverse_id
+
+      expect(resp['id']).to eql(@card_id)
+      expect(resp['object']).to eql('card')
+      expect(resp['multiverse_ids']).to include(@multiverse_id)
+    end
+
+    it 'should get a card by its Cardmarket id' do
+      resp = Scryfall::Cards.with_cardmarket_id @cardmarket_id
+
+      expect(resp['id']).to eql(@card_id)
+      expect(resp['object']).to eql('card')
+      expect(resp['cardmarket_id']).to eql(@cardmarket_id)
     end
   end
 end


### PR DESCRIPTION
Resolves https://github.com/jlcarruda/scryfall-rails/issues/15 adding support for multiverse and cardmarket ID lookups. Also bumps the gem version.