### PR TITLE
gemspec: Add resolv-replace gem to satisfy Ruby deprecation issues

### DIFF
--- a/scryfall.gemspec
+++ b/scryfall.gemspec
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+#git@github.com:hslzr/scryfall-rails.git frozen_string_literal: true
 
 Gem::Specification.new do |s|
   s.name        = 'scryfall'
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.2'
   s.add_development_dependency 'rubocop'
   s.add_runtime_dependency 'http', ['~> 4']
+  s.add_runtime_dependency 'resolv-replace', ['~> 0.1.1']
 end

--- a/scryfall.gemspec
+++ b/scryfall.gemspec
@@ -1,4 +1,4 @@
-#git@github.com:hslzr/scryfall-rails.git frozen_string_literal: true
+# frozen_string_literal: true
 
 Gem::Specification.new do |s|
   s.name        = 'scryfall'


### PR DESCRIPTION
Installed `scryfall` into my local environment and got the following deprecation warning:

```shell
warning: /Users/xxx/.asdf/installs/ruby/3.3.3/lib/ruby/3.3.0/resolv-replace.rb
was loaded from the standard library, but will no longer be part of the default
gems since Ruby 3.4.0. Add resolv-replace to your Gemfile or gemspec. Also
contact author of scryfall-0.2.10 to add resolv-replace into its gemspec.
```

So I added the dependency to get rid of that deprecation message and have no problems for whoever runs this on Ruby 3.4 next year.

EDIT: formatting