### PR TITLE
Add  required headers to each request.

### DIFF
--- a/lib/scryfall/api.rb
+++ b/lib/scryfall/api.rb
@@ -13,7 +13,9 @@ module Scryfall
     end
 
     def get(path = '', params = {}, **args)
-      res = HTTP.get(mount_uri(path), params: params)
+      res = HTTP
+        .headers('Accept' => '*/*', 'User-Agent' => "scryfall-rails/#{Scryfall::VERSION}")
+        .get(mount_uri(path), params: params)
 
       if args.key?(:to_struct) && args[:to_struct] == true
         JSON.parse res, object_class: OpenStruct

--- a/lib/scryfall/version.rb
+++ b/lib/scryfall/version.rb
@@ -1,0 +1,3 @@
+module Scryfall
+  VERSION = '0.3.0'
+end

--- a/scryfall.gemspec
+++ b/scryfall.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |s|
   s.email       = 'jlcarruda3@gmail.com'
   s.files       = ['lib/scryfall/cards.rb',
                    'lib/scryfall/error_handler.rb',
+                   'lib/scryfall/version.rb',
                    'lib/scryfall/errors.rb',
                    'lib/scryfall/api.rb',
                    'lib/scryfall/base.rb']

--- a/spec/scryfall_spec.rb
+++ b/spec/scryfall_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'scryfall/cards'
+require 'scryfall/version'
 
 describe Scryfall::Cards do
   describe 'Cards By Name' do


### PR DESCRIPTION
As of August 8th, 2024, the [Scryfall API is now requiring the `Accept` and `User-Agent` headers in each request](https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225). While the requests are still working, maybe we don't wanna risk them being rejected somewhere in the future.

It also adds a `VERSION` constant so we can add it to the `User-Agent` header.